### PR TITLE
ci: run CI/deploy jobs on self-hosted am-github-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,6 @@ jobs:
     with:
       docker-image: ghcr.io/aplinkosministerija/example
       environment: test
-      runs-on: ubuntu-latest
+      runs-on: am-github-runner
       latest-tag: true
       push: false


### PR DESCRIPTION
## Kodėl

Org Actions spending limit blokuoja GitHub-hosted runnerius (`job was not started because recent account payments have failed or your spending limit needs to be increased`). Vakar dėl to krito HR deploy'ai. Standartas — naudoti jau egzistuojantį self-hosted `am-github-runner` (ARC, Default runner group, matomas visiems org repams).

## Kas pakeista

Inline CI/deploy jobų `runs-on: ubuntu-latest` → `am-github-runner`.

- Saugumo skenai (CodeQL / Checkov / Scorecards) **palikti** ant `ubuntu-latest`.
- Deploy'ai per reusable workflow'us automatiškai migruoja per **AplinkosMinisterija/reusable-workflows#32** (`runs-on` default flip) — jiems atskiro pakeitimo nereikia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)