### PR TITLE
gyvunai: map USER_ADMIN to auth group-ADMIN (member management)

### DIFF
--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -245,7 +245,9 @@ export default class AuthService extends moleculer.Service {
     const oldTenantUser = ctx.params.oldData as TenantUser;
 
     const roleToAuthGroupRole = (role: TenantUserRole): AuthGroupRole =>
-      role === TenantUserRole.OWNER ? AuthGroupRole.ADMIN : AuthGroupRole.USER;
+      role === TenantUserRole.OWNER || role === TenantUserRole.USER_ADMIN
+        ? AuthGroupRole.ADMIN
+        : AuthGroupRole.USER;
 
     const authRole = roleToAuthGroupRole(tenantUser.role);
     const oldAuthRole = roleToAuthGroupRole(oldTenantUser.role);

--- a/services/tenantUsers.service.ts
+++ b/services/tenantUsers.service.ts
@@ -225,7 +225,10 @@ export default class TenantUsersService extends moleculer.Service {
 
     const tenant: Tenant = await ctx.call('tenants.resolve', { id: tenantId });
 
-    const authRole = role === TenantUserRole.OWNER ? AuthGroupRole.ADMIN : AuthGroupRole.USER;
+    const authRole =
+      role === TenantUserRole.OWNER || role === TenantUserRole.USER_ADMIN
+        ? AuthGroupRole.ADMIN
+        : AuthGroupRole.USER;
 
     const inviteData: any = {
       personalCode,


### PR DESCRIPTION
## What
Map **both `OWNER` and `USER_ADMIN`** to `AuthGroupRole.ADMIN` in the invite path and the `tenantUsers.updated` event. Previously only `OWNER → ADMIN`.

## Why
The upcoming **biip-auth-api release** authorizes `userGroups.assign`/`unassign` and the `usersEvartai.invite` companyId path by **group-admin membership** (`getVisibleGroupsIds({edit:true})`) instead of the old global type gate. `biip-medziokle-api` maps `USER_ADMIN → group-ADMIN`, so its managers pass; gyvunai mapped `USER_ADMIN → group-USER`, so a **USER_ADMIN manager would 403 on adding/removing members** once auth-api ships.

## Notes — @LWangllix (gyvunai half of the auth assign/unassign fix)
- Code fixes **future** invites/role-changes only. **3 existing `USER_ADMIN` memberships** in prod still have auth group role `USER` and need a one-time re-sync to `ADMIN` (auth `user_groups.role`) — done separately after this + the auth-api release.
- Harmless before auth-api ships (assign/unassign ungated at current prod auth 1.4.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)