### PR TITLE
Respect client sort param in list endpoints

### DIFF
--- a/mixins/profile.mixin.ts
+++ b/mixins/profile.mixin.ts
@@ -3,15 +3,33 @@ import { AuthUserRole, UserAuthMeta } from '../services/api.service';
 
 export default {
   methods: {
+    // Leidžia rūšiuoti tik pagal realias (ne virtualias) lenteles kolonas —
+    // kitaip knex sugeneruoja `"user"."firstName"` tipo SQL ir užklausa lūžta.
+    sanitizeSort(sort?: string | string[]): string[] | undefined {
+      if (!sort) return undefined;
+
+      const items = Array.isArray(sort)
+        ? sort
+        : String(sort).replace(/,/g, ' ').split(' ').filter(Boolean);
+
+      const sortable = items.filter((item) => {
+        const fieldName = String(item).replace(/^-/, '');
+        return this.$fields?.some((field: any) => field.name === fieldName && !field.virtual);
+      });
+
+      return sortable.length ? sortable : undefined;
+    },
+
     applyAccessFilter(ctx: Context<any, UserAuthMeta>, useRawUsers = false) {
       const { meta } = ctx;
       if (!meta) return ctx;
+
+      ctx.params.sort = this.sanitizeSort(ctx.params.sort) || '-createdAt';
 
       const { authUser, profile, user } = meta;
 
       const isAdmin = [AuthUserRole.SUPER_ADMIN, AuthUserRole.ADMIN].includes(authUser?.type);
       if (isAdmin) {
-        ctx.params.sort = '-createdAt';
         return ctx;
       }
 
@@ -29,7 +47,6 @@ export default {
           ctx.params.query = {
             $raw: { condition: 'FALSE', bindings: [] },
           };
-          ctx.params.sort = '-createdAt';
           return ctx;
         }
 
@@ -51,7 +68,6 @@ export default {
         }
       }
 
-      ctx.params.sort = '-createdAt';
       return ctx;
     },
 

--- a/test/profile.mixin.spec.ts
+++ b/test/profile.mixin.spec.ts
@@ -1,0 +1,74 @@
+'use strict';
+
+import ProfileMixin from '../mixins/profile.mixin';
+import { AuthUserRole } from '../services/api.service';
+
+const FIELDS = [
+  { name: 'id' },
+  { name: 'permitNumber' },
+  { name: 'createdAt' },
+  { name: 'municipality' },
+  { name: 'markingRecord', virtual: true },
+];
+
+const createService = () => ({
+  ...ProfileMixin.methods,
+  $fields: FIELDS,
+});
+
+const createCtx = (params: any = {}, meta: any = { authUser: { type: AuthUserRole.ADMIN } }) => ({
+  params,
+  meta,
+});
+
+describe('profile.mixin beforeSelect sort handling', () => {
+  it('keeps the sort requested by the client', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(createCtx({ sort: ['-permitNumber'] }) as any);
+
+    expect(ctx.params.sort).toEqual(['-permitNumber']);
+  });
+
+  it('applies the default sort when the client sends none', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(createCtx() as any);
+
+    expect(ctx.params.sort).toEqual('-createdAt');
+  });
+
+  it('keeps client sort for non-admin users as well', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(
+      createCtx(
+        { sort: 'permitNumber' },
+        { authUser: { type: AuthUserRole.USER }, user: { id: 5 } },
+      ) as any,
+    );
+
+    expect(ctx.params.sort).toEqual(['permitNumber']);
+    expect(ctx.params.query).toEqual({ user: 5 });
+  });
+
+  it('drops sort keys that are not real table columns', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(
+      createCtx({ sort: ['-user.firstName', 'permitNumber'] }) as any,
+    );
+
+    expect(ctx.params.sort).toEqual(['permitNumber']);
+  });
+
+  it('drops sort keys pointing to virtual fields', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(createCtx({ sort: ['markingRecord'] }) as any);
+
+    expect(ctx.params.sort).toEqual('-createdAt');
+  });
+
+  it('falls back to the default sort when no requested key is sortable', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(createCtx({ sort: ['municipality.name'] }) as any);
+
+    expect(ctx.params.sort).toEqual('-createdAt');
+  });
+});


### PR DESCRIPTION
## Kas padaryta
Administravimo sąsajos siunčiamas stulpelių rūšiavimas dabar realiai pasiekia duomenų bazę. Prieigos filtro hook'as (`profile.mixin.ts`) besąlygiškai perrašydavo `ctx.params.sort` į `-createdAt`, todėl rūšiavimas buvo tyliai ignoruojamas visuose NLG sąrašuose (leidimai, rūšys, gyvūnai, globojami gyvūnai, įrašai, įmonių naudotojai).

Dabar `-createdAt` taikomas tik kaip numatytasis, kai klientas rūšiavimo neatsiuntė. Atsiųsti rūšiavimo raktai papildomai filtruojami iki realių (ne virtualių) lentelės kolonų, kad raktai kaip `user.firstName` ar JSONB laukai negalėtų sugeneruoti neteisingo SQL.

## Kodėl
Taiso AplinkosMinisterija/biip-admin-web#509 (rūšiavimas neveikia visame NLLG modulyje). Susijęs UI pakeitimas: AplinkosMinisterija/biip-admin-web#511.

## Pastabos
Pridėti mixin'o unit testai (`test/profile.mixin.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)