### PR TITLE
gyvunai: rūšiavimas pagal rūšies pavadinimą species ir records sąrašuose

### DIFF
--- a/mixins/profile.mixin.ts
+++ b/mixins/profile.mixin.ts
@@ -1,6 +1,11 @@
 import { Context } from 'moleculer';
 import { AuthUserRole, UserAuthMeta } from '../services/api.service';
 
+type ProcessedField = { name: string; virtual?: boolean };
+
+const isRealColumn = (fields: ProcessedField[] | undefined, fieldName: string): boolean =>
+  !!fields?.some((field) => field.name === fieldName && !field.virtual);
+
 export default {
   methods: {
     // Leidžia rūšiuoti tik pagal realias (ne virtualias) lenteles kolonas —
@@ -12,12 +17,30 @@ export default {
         ? sort
         : String(sort).replace(/,/g, ' ').split(' ').filter(Boolean);
 
-      const sortable = items.filter((item) => {
-        const fieldName = String(item).replace(/^-/, '');
-        return this.$fields?.some((field: any) => field.name === fieldName && !field.virtual);
-      });
+      const sortable = items.filter((item) => this.isSortableField(String(item).replace(/^-/, '')));
 
       return sortable.length ? sortable : undefined;
+    },
+
+    isSortableField(fieldName: string): boolean {
+      const [rootField, ...nestedParts] = fieldName.split('.');
+
+      if (!nestedParts.length) {
+        return isRealColumn(this.$fields, fieldName);
+      }
+
+      // Taškuotas raktas (pvz. `speciesClassifier.name`) rūšiuoja per susijusią
+      // lentelę — leidžiama tik kai šakninis laukas turi service tipo `deepQuery`
+      // (tada moleculer-accounts DeepQueryMixin pats prijungia lentelę), o likusi
+      // dalis yra reali to serviso kolona.
+      if (nestedParts.length !== 1) return false;
+
+      const deepQuery = this.settings?.fields?.[rootField]?.deepQuery;
+      const serviceName = typeof deepQuery === 'string' ? deepQuery : deepQuery?.service;
+      if (typeof serviceName !== 'string') return false;
+
+      const service = this.broker?.getLocalService(serviceName);
+      return isRealColumn(service?.$fields, nestedParts[0]);
     },
 
     applyAccessFilter(ctx: Context<any, UserAuthMeta>, useRawUsers = false) {

--- a/services/records.service.ts
+++ b/services/records.service.ts
@@ -172,6 +172,7 @@ export type Record<
         type: 'number',
         columnType: 'integer',
         columnName: 'speciesClassifierId',
+        deepQuery: 'speciesClassifiers',
         populate: {
           action: 'speciesClassifiers.resolve',
         },

--- a/services/species.service.ts
+++ b/services/species.service.ts
@@ -132,6 +132,7 @@ const SPECIES_ACTION_PAGINATION_PARAMS = {
         columnType: 'integer',
         columnName: 'speciesClassifierId',
         required: true,
+        deepQuery: 'speciesClassifiers',
         populate: {
           action: 'speciesClassifiers.resolve',
         },

--- a/test/profile.mixin.spec.ts
+++ b/test/profile.mixin.spec.ts
@@ -8,12 +8,25 @@ const FIELDS = [
   { name: 'permitNumber' },
   { name: 'createdAt' },
   { name: 'municipality' },
+  { name: 'speciesClassifier' },
   { name: 'markingRecord', virtual: true },
 ];
+
+const SPECIES_CLASSIFIER_FIELDS = [{ name: 'id' }, { name: 'name' }, { name: 'nameLatin' }];
 
 const createService = () => ({
   ...ProfileMixin.methods,
   $fields: FIELDS,
+  settings: {
+    fields: {
+      municipality: 'any',
+      speciesClassifier: { deepQuery: 'speciesClassifiers' },
+    },
+  },
+  broker: {
+    getLocalService: (name: string) =>
+      name === 'speciesClassifiers' ? { $fields: SPECIES_CLASSIFIER_FIELDS } : undefined,
+  },
 });
 
 const createCtx = (params: any = {}, meta: any = { authUser: { type: AuthUserRole.ADMIN } }) => ({
@@ -68,6 +81,27 @@ describe('profile.mixin beforeSelect sort handling', () => {
   it('falls back to the default sort when no requested key is sortable', () => {
     const service = createService();
     const ctx = service.beforeSelect(createCtx({ sort: ['municipality.name'] }) as any);
+
+    expect(ctx.params.sort).toEqual('-createdAt');
+  });
+
+  it('keeps dotted sort keys backed by a deepQuery relation', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(createCtx({ sort: ['-speciesClassifier.name'] }) as any);
+
+    expect(ctx.params.sort).toEqual(['-speciesClassifier.name']);
+  });
+
+  it('drops dotted sort keys whose column does not exist on the related service', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(createCtx({ sort: ['speciesClassifier.bogus'] }) as any);
+
+    expect(ctx.params.sort).toEqual('-createdAt');
+  });
+
+  it('drops dotted sort keys deeper than one relation level', () => {
+    const service = createService();
+    const ctx = service.beforeSelect(createCtx({ sort: ['speciesClassifier.family.name'] }) as any);
 
     expect(ctx.params.sort).toEqual('-createdAt');
   });


### PR DESCRIPTION
## Kas padaryta

Įgalintas serverio pusės rūšiavimas pagal rūšies pavadinimą (`speciesClassifier.name`) `species` ir `records` sąrašų endpoint'uose — administravimo aplinkos „Gyvūnų rūšys“ ir „Gyvūnų žurnalas“ lentelės galės rūšiuoti pagal stulpelį „Pavadinimas“.

- `species` ir `records` servisų `speciesClassifier` laukui pridėtas `deepQuery: 'speciesClassifiers'` — `moleculer-accounts` DeepQueryMixin pats prijungia klasifikatorių lentelę (LEFT JOIN) ir rūšiuoja pagal jos stulpelį.
- `profile.mixin.ts` `sanitizeSort` praleidžia vieno lygio taškuotus raktus, kai šakninis laukas turi service tipo `deepQuery`, o likusi dalis yra reali to serviso kolona; visi kiti raktai kaip ir anksčiau išmetami.

## Kodėl

https://github.com/AplinkosMinisterija/biip-admin-web/issues/516 — tęsinys po biip-admin-web#509: paprašyta rūšiavimo stulpeliui „Pavadinimas“.

## Pastabos

- Patikrinta end-to-end prieš lokalią DB: `species.list` / `records.list` su `sort=speciesClassifier.name` (ASC ir DESC) grąžina teisinga tvarka, neteisingas raktas saugiai atkrenta į `-createdAt`.
- Diegti prieš biip-admin-web PR, kuris grąžina rūšiavimo rodykles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)